### PR TITLE
Adds tests for bitfield module.

### DIFF
--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -47,3 +47,56 @@ fn full_division(n: usize, radix: usize) -> (usize, usize) {
     let quo = n / radix;
     (quo, n - radix * quo)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let i = BitField::new(17);
+        // 17 bits means rounding off to 3 bytes
+        // with the last byte having mask = 1
+        assert_eq!(i.mask, 1);
+
+        let i = BitField::new(19);
+        // 19 bits means rounding off to 3 bytes
+        // with the last byte having mask = 7
+        assert_eq!(i.mask, 7);
+
+        let i = BitField::new(24);
+        // 24 bits means exactly 3 bytes
+        // with the last byte having mask = 0
+        assert_eq!(i.mask, 0);
+    }
+
+    #[test]
+    fn test_increment() {
+        let mut i = BitField::new(8);
+        i.increment();
+        // the value for the bitfield now is 1
+        assert!(i.at(0));
+
+        // we add 3 to the bitfield
+        for _ in 0..3 {
+            i.increment();
+        }
+        // the total value now is 4
+        // and 1 << 2 is 4
+        assert!(i.at(2));
+
+        // the last two bits must be zero
+        assert!(!i.at(1));
+        assert!(!i.at(0));
+    }
+
+    #[test]
+    fn test_maxed() {
+        let mut i = BitField::new(8);
+        // an 8 bit vector will max at 255
+        for _ in 0..=255 {
+            i.increment();
+        }
+        assert!(i.maxed());
+    }
+}


### PR DESCRIPTION
### Tests:
- `test_new`: Tests for the `new` function to make sure the mask for the highest bit corresponds to the bitvector size supplied, independent of whether it is a multiple of 8.
- `test_increment`: Tests for the `increment` function to increment the bitvector as one big unsigned integer.
- `test_maxed`: Tests for the `maxed` function. After multiple increments till the bitvector's limit, the `maxed` function should return true,