### PR TITLE
fix: improve signal handling and error messages in case of panics

### DIFF
--- a/src/glob.rs
+++ b/src/glob.rs
@@ -1,4 +1,5 @@
 use crate::bitfield::BitField;
+use color_eyre::eyre::WrapErr;
 use crossbeam::channel::{Receiver, Sender};
 use std::{collections::HashMap, sync::Arc};
 
@@ -200,7 +201,8 @@ pub fn generate(
                     &job.substring,
                     &path,
                 ))
-                .unwrap();
+                .wrap_err("broken pipe or forced halt")
+                .expect("unable to send result from worker");
             }
             i.increment();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,10 @@ mod env;
 mod glob;
 mod substring;
 mod syntax;
-use signal_hook::{consts::SIGPIPE, iterator::Signals};
+use signal_hook::{
+    consts::{SIGINT, SIGPIPE},
+    iterator::Signals,
+};
 
 #[derive(Parser)]
 #[command(author, version, about = None)]
@@ -48,7 +51,7 @@ pub struct Args {
 fn main() -> Result<()> {
     color_eyre::install()?;
 
-    let mut signals = Signals::new([SIGPIPE])?;
+    let mut signals = Signals::new([SIGPIPE, SIGINT])?;
 
     let args = Args::parse();
     let path = args.path.to_lowercase();
@@ -94,7 +97,7 @@ fn main() -> Result<()> {
 
         scope.spawn(|_| {
             for sig in signals.forever() {
-                if SIGPIPE == sig {
+                if SIGPIPE == sig || SIGINT == sig {
                     std::process::exit(1);
                 }
             }


### PR DESCRIPTION
### Changes:
- Includes `SIGINT` in the signal handling routine
- Wrap any of the worker channel's send errors with a reason (broken pipe or forced halt) and provide a message explaining the situation.